### PR TITLE
Remove empty triple-slash directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rollup-plugin-ts",
-	"version": "3.2.0",
+	"version": "3.2.0-mxdvl.1",
 	"description": "A TypeScript Rollup plugin that bundles declarations, respects Browserslists, and enables seamless integration with transpilers such as babel and swc",
 	"scripts": {
 		"generate:sandhog": "sandhog all --yes",
@@ -102,7 +102,8 @@
 		"typescript-4-5-4": "npm:typescript@4.5.4",
 		"typescript-4-6-4": "npm:typescript@4.6.4",
 		"typescript-4-7-2": "npm:typescript@4.7.2",
-		"typescript-4-8-2": "npm:typescript@4.8.2"
+		"typescript-4-8-2": "npm:typescript@4.8.2",
+		"typescript-5-1-3": "npm:typescript@5.1.3"
 	},
 	"dependencies": {
 		"@rollup/pluginutils": "^5.0.2",
@@ -125,7 +126,7 @@
 		"@swc/core": ">=1.x",
 		"@swc/helpers": ">=0.2",
 		"rollup": ">=1.x || >=2.x",
-		"typescript": ">=3.2.x || >= 4.x"
+		"typescript": ">=3.2.x || >=4.x || <=5.2"
 	},
 	"peerDependenciesMeta": {
 		"@babel/core": {
@@ -176,6 +177,7 @@
 		"yarn": ">=1.13",
 		"pnpm": ">=3.2.0"
 	},
+	"packageManager": "pnpm@7.18.1",
 	"prettier": "@wessberg/prettier-config",
 	"ava": {
 		"files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,7 @@ specifiers:
   typescript-4-6-4: npm:typescript@4.6.4
   typescript-4-7-2: npm:typescript@4.7.2
   typescript-4-8-2: npm:typescript@4.8.2
+  typescript-5-1-3: npm:typescript@5.1.3
 
 dependencies:
   '@rollup/pluginutils': 5.0.2_rollup@3.10.1
@@ -137,6 +138,7 @@ devDependencies:
   typescript-4-6-4: /typescript/4.6.4
   typescript-4-7-2: /typescript/4.7.2
   typescript-4-8-2: /typescript/4.8.2
+  typescript-5-1-3: /typescript/5.1.3
 
 packages:
 
@@ -8080,6 +8082,12 @@ packages:
     resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+
+  /typescript/5.1.3:
+    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
 
   /ua-parser-js/1.0.33:
     resolution: {integrity: sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ==}

--- a/src/service/transformer/declaration-bundler/transformers/source-file-bundler/source-file-bundler.ts
+++ b/src/service/transformer/declaration-bundler/transformers/source-file-bundler/source-file-bundler.ts
@@ -173,6 +173,9 @@ export function sourceFileBundler(options: DeclarationBundlerOptions, ...transfo
 			}
 		}
 
+		libReferenceDirectiveFileNames.delete("");
+		typeReferenceDirectiveFileNames.delete("");
+
 		for (const fileName of libReferenceDirectiveFileNames) {
 			prepends.push(typescript.createUnparsedSourceFile(formatLibReferenceDirective(fileName)));
 		}


### PR DESCRIPTION
This enables support for TS 5.1 on https://github.com/guardian/csnx

cc. @joecowton1 this actually fixes https://github.com/guardian/csnx/pull/662
